### PR TITLE
Add Arquillian-BOM to the dependencyManagement section

### DIFF
--- a/camunda-archetype-ejb-war/pom.xml
+++ b/camunda-archetype-ejb-war/pom.xml
@@ -19,6 +19,7 @@
 
   <properties>
     <version.camunda>${camunda.version}</version.camunda>
+    <version.arquillian>${arquillian.version}</version.arquillian>
     <version.jboss>${jboss.version}</version.jboss>
     <version.tomcat>${tomcat.version}</version.tomcat>
   </properties>

--- a/camunda-archetype-ejb-war/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/camunda-archetype-ejb-war/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <requiredProperties>
     <requiredProperty key="camunda-version"><defaultValue>${version.camunda}</defaultValue></requiredProperty>
+    <requiredProperty key="arquillian-version"><defaultValue>${version.arquillian}</defaultValue></requiredProperty>
     <requiredProperty key="jboss-version"><defaultValue>${version.jboss}</defaultValue></requiredProperty>
   </requiredProperties>
   <fileSets>

--- a/camunda-archetype-ejb-war/src/main/resources/archetype-resources/pom.xml
+++ b/camunda-archetype-ejb-war/src/main/resources/archetype-resources/pom.xml
@@ -14,9 +14,21 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <camunda.version>${camunda-version}</camunda.version>
+    <arquillian.version>${arquillian-version}</arquillian.version>
     <jboss.version>${jboss-version}</jboss.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${arquillian.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <!-- process engine, needs to be provided -->
@@ -71,7 +83,6 @@
       <!-- Needed for ArquillianTest -->
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <version>1.0.3.Final</version>
       <scope>test</scope>
     </dependency>
 

--- a/camunda-archetype-ejb-war/src/test/resources/projects/basic/archetype.properties
+++ b/camunda-archetype-ejb-war/src/test/resources/projects/basic/archetype.properties
@@ -4,4 +4,5 @@ version=0.1-SNAPSHOT
 groupId=com.camunda.bpm.demo.outerspace
 artifactId=basic
 camunda-version=${version.camunda}
+arquillian-version=${version.arquillian}
 jboss-version=${version.jboss}

--- a/camunda-archetype-servlet-war/pom.xml
+++ b/camunda-archetype-servlet-war/pom.xml
@@ -19,6 +19,7 @@
 
   <properties>
     <version.camunda>${camunda.version}</version.camunda>
+    <version.arquillian>${arquillian.version}</version.arquillian>
     <version.jboss>${jboss.version}</version.jboss>
     <version.tomcat>${tomcat.version}</version.tomcat>
   </properties>

--- a/camunda-archetype-servlet-war/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/camunda-archetype-servlet-war/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <requiredProperties>
     <requiredProperty key="camunda-version"><defaultValue>${version.camunda}</defaultValue></requiredProperty>
+    <requiredProperty key="arquillian-version"><defaultValue>${version.arquillian}</defaultValue></requiredProperty>
     <requiredProperty key="jboss-version"><defaultValue>${version.jboss}</defaultValue></requiredProperty>
     <requiredProperty key="tomcat-version"><defaultValue>${version.tomcat}</defaultValue></requiredProperty>
   </requiredProperties>

--- a/camunda-archetype-servlet-war/src/main/resources/archetype-resources/pom.xml
+++ b/camunda-archetype-servlet-war/src/main/resources/archetype-resources/pom.xml
@@ -14,9 +14,21 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <camunda.version>${camunda-version}</camunda.version>
+    <arquillian.version>${arquillian-version}</arquillian.version>
     <jboss.version>${jboss-version}</jboss.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${arquillian.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <!-- process engine -->
@@ -44,7 +56,6 @@
       <!-- Needed for ArquillianTest -->
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <version>1.0.3.Final</version>
       <scope>test</scope>
     </dependency>
 

--- a/camunda-archetype-servlet-war/src/test/resources/projects/basic/archetype.properties
+++ b/camunda-archetype-servlet-war/src/test/resources/projects/basic/archetype.properties
@@ -4,5 +4,6 @@ version=0.1-SNAPSHOT
 groupId=com.camunda.bpm.demo.outerspace
 artifactId=basic
 camunda-version=${version.camunda}
+arquillian-version=${version.arquillian}
 jboss-version=${version.jboss}
 tomcat-version=${version.tomcat}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 
     <camunda.version>7.0.0-Final</camunda.version>
     <jboss.version>7.1.3.Final</jboss.version>
+    <arquillian.version>1.0.3.Final</arquillian.version>
     <tomcat.version>7.0.33</tomcat.version>
   </properties>
 


### PR DESCRIPTION
Arquillian rely on Mavens import scope to set the versions
of Core used between the arquillian-junit-container artifact
and the provided Arquillian Container adapter.
