### PR TITLE
maint(maven/pom): use camunda bom for proper dependency mngt.

### DIFF
--- a/camunda-archetype-cockpit-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/camunda-archetype-cockpit-plugin/src/main/resources/archetype-resources/pom.xml
@@ -26,11 +26,24 @@
     <camunda.plugin.language>${camunda-plugin-language}</camunda.plugin.language>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.camunda.bpm</groupId>
+        <artifactId>camunda-bom</artifactId>
+        <version>${camunda.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <!-- Cockpit Plugin API, needs to be provided -->
       <groupId>org.camunda.bpm.webapp</groupId>
       <artifactId>camunda-webapp-core</artifactId>
+      <!-- not part of camunda bom -->
       <version>${camunda.version}</version>
       <scope>provided</scope>
     </dependency>  
@@ -38,7 +51,6 @@
       <!-- process engine, needs to be provided -->
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine</artifactId>
-      <version>${camunda.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/camunda-archetype-ejb-war/src/main/resources/archetype-resources/pom.xml
+++ b/camunda-archetype-ejb-war/src/main/resources/archetype-resources/pom.xml
@@ -21,6 +21,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.camunda.bpm</groupId>
+        <artifactId>camunda-bom</artifactId>
+        <version>${camunda.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
         <!-- Needed for ArquillianTest -->
         <groupId>org.jboss.arquillian</groupId>
         <artifactId>arquillian-bom</artifactId>
@@ -36,20 +43,17 @@
       <!-- process engine, needs to be provided -->
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine</artifactId>
-      <version>${camunda.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- client for Java EE application server integration, included in WAR as an alternative to write your own ProcessApplication class -->
       <groupId>org.camunda.bpm.javaee</groupId>
       <artifactId>camunda-ejb-client</artifactId>
-      <version>${camunda.version}</version>
     </dependency>
     <dependency>
       <!-- CDI integration, needs to be included in WAR, otherwise CDI can not work correctly -->
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine-cdi</artifactId>
-      <version>${camunda.version}</version>
     </dependency>
 
     <dependency>
@@ -59,20 +63,18 @@
       <version>1.2</version>
       <scope>test</scope>
     </dependency>
-    
-    <!-- Required to use Sping dataformat in unit tests -->
+
+    <!-- Required to use Spin dataformat in unit tests -->
     <dependency>
-			<groupId>org.camunda.spin</groupId>
-			<artifactId>camunda-spin-dataformat-all</artifactId>
-			<version>1.0.0</version>
+      <groupId>org.camunda.spin</groupId>
+      <artifactId>camunda-spin-dataformat-all</artifactId>
       <scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.camunda.bpm</groupId>
-			<artifactId>camunda-engine-plugin-spin</artifactId>
-			<version>${camunda.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine-plugin-spin</artifactId>
       <scope>test</scope>
-		</dependency>
+    </dependency>
 
     <dependency>
       <!-- Bootstrap for styling via Webjars project -->

--- a/camunda-archetype-servlet-war/src/main/resources/archetype-resources/pom.xml
+++ b/camunda-archetype-servlet-war/src/main/resources/archetype-resources/pom.xml
@@ -16,12 +16,23 @@
     <camunda.version>${camunda-version}</camunda.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.camunda.bpm</groupId>
+        <artifactId>camunda-bom</artifactId>
+        <version>${camunda.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <!-- process engine, needs to be provided -->
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine</artifactId>
-      <version>${camunda.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -33,19 +44,17 @@
       <scope>test</scope>
     </dependency>
     
-    <!-- Required to use Sping dataformat in unit tests -->
+    <!-- Required to use Spin dataformat in unit tests -->
     <dependency>
-			<groupId>org.camunda.spin</groupId>
-			<artifactId>camunda-spin-dataformat-all</artifactId>
-			<version>1.0.0</version>
+      <groupId>org.camunda.spin</groupId>
+      <artifactId>camunda-spin-dataformat-all</artifactId>
       <scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.camunda.bpm</groupId>
-			<artifactId>camunda-engine-plugin-spin</artifactId>
-			<version>${camunda.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine-plugin-spin</artifactId>
       <scope>test</scope>
-		</dependency>    
+    </dependency>
 
     <dependency>
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Import camunda bom to ensure users always use the matching camunda
engine spin / connect versions.

I hope the changes are correct, I am not very experienced in the creation of maven archetypes