### PR TITLE
Fix LoggerDelegate.execute method word mistake

### DIFF
--- a/camunda-archetype-servlet-war/src/main/resources/archetype-resources/src/main/java/LoggerDelegate.java
+++ b/camunda-archetype-servlet-war/src/main/resources/archetype-resources/src/main/java/LoggerDelegate.java
@@ -17,8 +17,8 @@ public class LoggerDelegate implements JavaDelegate {
   public void execute(DelegateExecution execution) throws Exception {
     
     LOGGER.info("\n\n  ... LoggerDelegate invoked by "
-            + "activtyName='" + execution.getCurrentActivityName() + "'"
-            + ", activtyId=" + execution.getCurrentActivityId()
+            + "activityName='" + execution.getCurrentActivityName() + "'"
+            + ", activityId=" + execution.getCurrentActivityId()
             + ", processDefinitionId=" + execution.getProcessDefinitionId()
             + ", processInstanceId=" + execution.getProcessInstanceId()
             + ", businessKey=" + execution.getProcessBusinessKey()


### PR DESCRIPTION
Hi, 
I am posting an unimportant word mistake fix.
LoggerDelegate.execute method, LOGGER.info("activty" --> "activity