### PR TITLE
chore: switch to Sonatype Central Portal deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-release-parent</artifactId>
-    <version>3.7.2</version>
+    <version>3.7.4</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

This PR is part of our [migration](https://github.com/camunda/camunda-release-parent/blob/infra-833-prepare-migration/README.md) to the new Sonatype Central Portal, and upgrades the camunda-release-parent POM to the latest version.

Sonatype is deprecating the legacy OSSRH Staging API, and the migration affects all Camunda namespaces (io.camunda, org.camunda). Publishing via OSSRH will no longer be possible once the namespaces are migrated.